### PR TITLE
add app_url label

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -169,6 +170,13 @@ func (e *Exporter) scrapeApps(json *gabs.Container, ch chan<- prometheus.Metric)
 		grabbedLabels = append(grabbedLabels, label{
 			key:   "app_version",
 			value: version,
+		})
+		// Add an 'app_url' label which is a FQDN that loads marathon's details page
+		// for the given app. Useful to add on alerts.
+		appUrl := strings.TrimSuffix(stripAuthority(e.scraper.URL()), "/") + "/ui/#/apps/"
+		grabbedLabels = append(grabbedLabels, label{
+			key:   "app_url",
+			value: appUrl + url.PathEscape(id),
 		})
 		sortLabels(grabbedLabels)
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/matt-deboer/go-marathon"
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,7 +66,7 @@ func marathonConnect(uri *url.URL) error {
 		},
 	}
 
-	log.Debugln("Connecting to Marathon")
+	log.Debugf("Connecting to Marathon: %s | username=%s | len(password)=%d", stripAuthority(uri), user, utf8.RuneCountInString(pass))
 	client, err := marathon.NewClient(config)
 	if err != nil {
 		return err
@@ -78,6 +79,14 @@ func marathonConnect(uri *url.URL) error {
 
 	log.Debugf("Connected to Marathon! Name=%s, Version=%s\n", info.Name, info.Version)
 	return nil
+}
+
+func stripAuthority(u *url.URL) string {
+	_, passSet := u.User.Password()
+	if passSet {
+		return strings.Replace(u.String(), u.User.String()+"@", "", 1)
+	}
+	return u.String()
 }
 
 func main() {

--- a/scraper.go
+++ b/scraper.go
@@ -12,10 +12,15 @@ import (
 
 type Scraper interface {
 	Scrape(path string) ([]byte, error)
+	URL() *url.URL
 }
 
 type scraper struct {
 	uri *url.URL
+}
+
+func (s *scraper) URL() *url.URL {
+	return s.uri
 }
 
 func (s *scraper) Scrape(path string) ([]byte, error) {


### PR DESCRIPTION
Add an `app_url` label which is a FQDN that loads marathon's details page for the given app. Useful to add on alerts.

Example: 
```
marathon_app_task_avg_uptime{
  alert_channel="",
  alert_dashboard="",
  app="/foo",
  app_url="https://marathon.banno.com/ui/#/apps/%2Ffoo",
  app_version="2018-07-06T21:08:08.746Z",
  team="team-awesome"
} 348742.7825
```

Also, adds this line on startup: 

```
DEBU[0000] Connecting to Marathon: https://marathon.banno.com | username=awesome | len(password)=21  source=main.go:69
```